### PR TITLE
Remove trailing spaces from d.ts output

### DIFF
--- a/src/helpers.spec.ts
+++ b/src/helpers.spec.ts
@@ -11,7 +11,7 @@ test("if string is not a reserved keyword returns false", () => {
 
 test("if no options are set returns default banner message", () => {
   expect(buildbanner()).toBe(
-    `// This is an auto generated file. \n// Please do not edit. \n\n`
+    `// This is an auto generated file.\n// Please do not edit.\n\n`
   );
 });
 
@@ -22,7 +22,7 @@ test("if user sets `banner` to `false` it should return an empty string", () => 
 
 test("if user sets a banner message it should return it with the proper format", () => {
   const options: OptionsInterface = { banner: "I am a banner" };
-  const expectedResult = `// I am a banner \n\n`;
+  const expectedResult = `// I am a banner\n\n`;
   expect(buildbanner(options)).toBe(expectedResult);
 });
 
@@ -33,7 +33,7 @@ test("creates the correct Typescript syntax to export css types", () => {
       two: "_2e43ghnXX24M2ZFgLzgCyc"
     }
   };
-  const expected = `export const one: string; \nexport const two: string; \n`;
+  const expected = `export const one: string;\nexport const two: string;\n`;
   expect(buildTsExports(modulesExports, "style.scss")).toBe(expected);
 });
 
@@ -44,7 +44,7 @@ test("creates the correct Typescript syntax to export css types and ignore reser
       two: "_2e43ghnXX24M2ZFgLzgCyc"
     }
   };
-  const expected = `export const two: string; \n`;
+  const expected = `export const two: string;\n`;
   expect(buildTsExports(modulesExports, "style.scss")).toBe(expected);
 });
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -51,12 +51,12 @@ export function filterReservedKeywords(selector: string): boolean {
  * @param options string
  */
 export function buildbanner(options?: OptionsInterface): string {
-  let banner = `// This is an auto generated file. \n// Please do not edit. \n\n`;
+  let banner = `// This is an auto generated file.\n// Please do not edit.\n\n`;
   if (options) {
     if (options.banner === false) {
       banner = "";
     } else {
-      banner = `// ${options.banner} \n\n`;
+      banner = `// ${options.banner}\n\n`;
     }
   }
   return banner;
@@ -71,7 +71,7 @@ export function buildTsExports(moduleExports, filename: string): string {
   let cssModuleDefinition = "";
   Object.keys(moduleExports.locals).map(key => {
     if (!filterReservedKeywords(key)) {
-      cssModuleDefinition += `export const ${key}: string; \n`;
+      cssModuleDefinition += `export const ${key}: string;\n`;
     }
   });
   return cssModuleDefinition;


### PR DESCRIPTION
Trailing spaces are prohibited in majority of coding styles (including Prettier).
This pull-request makes sure, that generated code doesn't have them anymore (by default)